### PR TITLE
Add more robust IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,16 @@ Teleport stores the data locally under the `teleport_data_dir`.
     teleport_storage_type: 'bolt'
     teleport_pidfile: '/var/run/teleport.pid'
 
+    teleport_default_address: '0.0.0.0'
+
+This sets the default address used in the various `*_listen_address` variables
+below. The default of `'0.0.0.0'` means to listen on all IPv4 interfaces.
+Setting it to `'::'` would listen on all IPv6 (and IPv4, if your hosts have the
+appropriate networking option enabled) addresses. (Note that Teleport's IPv6
+support is not yet official; use this at your own risk.)
+
     teleport_auth_enabled: true
-    teleport_auth_listen_address: '0.0.0.0:3025'
+    teleport_auth_listen_address: '{{ teleport_default_address | ipwrap }}:3025'
     teleport_auth_cluster_name: 'main'
 
 
@@ -55,16 +63,16 @@ You probably want to have multiple nodes joined to our cluster. You can do that 
 
 If you don't want to login to this server using Teleport, only via the standard SSH way, disable the SSH service by setting this value to `false`.
     
-    teleport_ssh_listen_address: '0.0.0.0:3022'
+    teleport_ssh_listen_address: '{{ teleport_default_address | ipwrap }}:3022'
     teleport_commands: []
 
     teleport_proxy_enabled: true
 
 If you want to disable the WebUI (proxy), set this setting to `false`.
 
-    teleport_proxy_listen_address: '0.0.0.0:3023'
-    teleport_proxy_web_listen_address: '0.0.0.0:3080'
-    teleport_proxy_tunnel_listen_address: '0.0.0.0:3024'
+    teleport_proxy_listen_address: '{{ teleport_default_address | ipwrap }}:3023'
+    teleport_proxy_web_listen_address: '{{ teleport_default_address | ipwrap }}:3080'
+    teleport_proxy_tunnel_listen_address: '{{ teleport_default_address | ipwrap }}:3024'
     teleport_proxy_https_key_file: ''
     teleport_proxy_https_cert_file: ''
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ For full reference see the official [teleport documentation by gravitational](ht
 
 ## Dependencies
 
-None.
+- Ansible 2.4 or newer
+- Python `netaddr` package (available on Debian/EPEL as `python-netaddr`)
 
 ## Core Concepts
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,9 +12,11 @@ teleport_log_level: 'WARN'
 teleport_storage_type: 'bolt'
 teleport_pidfile: '/var/run/teleport.pid'
 
+teleport_default_address: '0.0.0.0'
+
 # auth service
 teleport_auth_enabled: true
-teleport_auth_listen_address: '0.0.0.0:3025'
+teleport_auth_listen_address: '{{ teleport_default_address | ipwrap }}:3025'
 teleport_auth_cluster_name: 'main'
 teleport_auth_tokens_node: []
 teleport_auth_tokens_proxy: []
@@ -24,13 +26,13 @@ teleport_auth_oidc_connectors: []
 
 # ssh service
 teleport_ssh_enabled: true
-teleport_ssh_listen_address: '0.0.0.0:3022'
+teleport_ssh_listen_address: '{{ teleport_default_address | ipwrap }}:3022'
 teleport_commands: []
 
 # proxy service
 teleport_proxy_enabled: true
-teleport_proxy_listen_address: '0.0.0.0:3023'
-teleport_proxy_web_listen_address: '0.0.0.0:3080'
-teleport_proxy_tunnel_listen_address: '0.0.0.0:3024'
+teleport_proxy_listen_address: '{{ teleport_default_address | ipwrap }}:3023'
+teleport_proxy_web_listen_address: '{{ teleport_default_address | ipwrap }}:3080'
+teleport_proxy_tunnel_listen_address: '{{ teleport_default_address | ipwrap }}:3024'
 teleport_proxy_https_key_file: ''
 teleport_proxy_https_cert_file: ''

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -2,14 +2,14 @@ teleport:
   nodename: {{ teleport_nodename }}
   pid_file: {{ teleport_pidfile }}
 {% if teleport_auth_token %}  
-  auth_token: {{ teleport_auth_token }}
+  auth_token: "{{ teleport_auth_token }}"
 {% endif %}
 {% if teleport_advertise_ip | default(false) %}
-  advertise_ip: {{ teleport_advertise_ip }}
+  advertise_ip: "{{ teleport_advertise_ip }}"
 {% endif %}
   auth_servers:
 {% for auth_server in teleport_auth_servers %}
-    - {{ auth_server }}
+    - "{{ auth_server }}"
 {% endfor %}
   connection_limits:
     max_connections: 1000
@@ -23,7 +23,7 @@ teleport:
 auth_service:
 {% if teleport_auth_enabled | default(false) %}
   enabled: "yes"
-  listen_addr: {{ teleport_auth_listen_address }}
+  listen_addr: "{{ teleport_auth_listen_address }}"
   oidc_connectors: []
   cluster_name: {{ teleport_auth_cluster_name }}
 {% if teleport_auth_trusted_clusters|length > 0 %}
@@ -50,16 +50,16 @@ auth_service:
 ssh_service:
 {% if teleport_ssh_enabled | default(false) %}
   enabled: "yes"
-  listen_addr: {{ teleport_ssh_listen_address }}
+  listen_addr: "{{ teleport_ssh_listen_address }}"
 {% else %}
   enabled: "no"
 {% endif %}
 proxy_service:
 {% if teleport_proxy_enabled | default(false) %}
   enabled: "yes"
-  listen_addr: {{ teleport_proxy_listen_address }}
-  web_listen_addr: {{ teleport_proxy_web_listen_address }}
-  tunnel_listen_addr: {{ teleport_proxy_tunnel_listen_address }}
+  listen_addr: "{{ teleport_proxy_listen_address }}"
+  web_listen_addr: "{{ teleport_proxy_web_listen_address }}"
+  tunnel_listen_addr: "{{ teleport_proxy_tunnel_listen_address }}"
 {% if teleport_proxy_https_key_file %}
   https_key_file: {{ teleport_proxy_https_key_file }}
   https_cert_file: {{ teleport_proxy_https_cert_file }}

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -17,6 +17,9 @@ RUN yum -y install epel-release
 RUN yum -y install git ansible sudo
 RUN yum clean all
 
+# Install python-netaddr
+RUN yum -y install python-netaddr
+
 # Disable requiretty
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 

--- a/tests/Dockerfile.fedora-24
+++ b/tests/Dockerfile.fedora-24
@@ -1,5 +1,8 @@
 FROM fedora:24
 RUN dnf -y install ansible
 
+# Install python-netaddr
+RUN dnf -y install python-netaddr
+
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -7,5 +7,8 @@ RUN apt-add-repository -y ppa:ansible/ansible
 RUN apt-get update
 RUN apt-get install -y ansible
 
+# Install python-netaddr
+RUN apt-get install -y python-netaddr
+
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-16.04
+++ b/tests/Dockerfile.ubuntu-16.04
@@ -7,5 +7,8 @@ RUN apt-add-repository -y ppa:ansible/ansible
 RUN apt-get update
 RUN apt-get install -y ansible
 
+# Install python-netaddr
+RUN apt-get install -y python-netaddr
+
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts


### PR DESCRIPTION
Hi! Thank you so much for developing this Ansible role; it's quite useful!

I use IPv6 heavily in my cluster and Teleport's YAML parser tends not to like it when an unquoted string begins with `[`, so I've added quotes around the variables in the `teleport.yaml.j2` template likely to begin with strange characters.

The second commit in this PR adds a new config variable to make it a bit easier to switch on IPv6 by default. (Noting, of course, that Gravitational still doesn't promise official Teleport IPv6 support - but it is quite good in my experience.)