### PR TITLE
Tell systemd to kill only the teleport process

### DIFF
--- a/templates/teleport.service.j2
+++ b/templates/teleport.service.j2
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 Restart=always
 ExecStart=/usr/local/bin/teleport start --config={{ teleport_config_path }} {{ teleport_opts | default('') }}
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This leaves subprocesses created by Teleport sessions alone
when restarting teleport.service

Fixes #8