### PR TITLE
U2F support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ You probably want to have multiple nodes joined to our cluster. You can do that 
     teleport_auth_oidc_connectors: []
 
 
+    teleport_u2f_app_id: 'https://teleport.master.fqdn:3080
+
+Setting `teleport_u2f_app_id` puts the Teleport cluster into U2F mode. Instead
+of using basic TOTP 2FA, users will be required to set up and use a FIDO U2F
+hardware key instead.
+
+
     teleport_ssh_enabled: true
 
 If you don't want to login to this server using Teleport, only via the standard SSH way, disable the SSH service by setting this value to `false`.

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -30,6 +30,8 @@ auth_service:
     second_factor: u2f
     u2f:
       app_id: "{{ teleport_u2f_app_id }}"
+      facets:
+        - "{{ teleport_u2f_app_id }}"
 {% endif %}
   oidc_connectors: []
   cluster_name: {{ teleport_auth_cluster_name }}

--- a/templates/teleport.yaml.j2
+++ b/templates/teleport.yaml.j2
@@ -24,6 +24,13 @@ auth_service:
 {% if teleport_auth_enabled | default(false) %}
   enabled: "yes"
   listen_addr: "{{ teleport_auth_listen_address }}"
+{% if teleport_u2f_app_id | default(false) %}
+  authentication:
+    type: local
+    second_factor: u2f
+    u2f:
+      app_id: "{{ teleport_u2f_app_id }}"
+{% endif %}
   oidc_connectors: []
   cluster_name: {{ teleport_auth_cluster_name }}
 {% if teleport_auth_trusted_clusters|length > 0 %}


### PR DESCRIPTION
This allows configuring the Teleport auth role for U2F TFA support, instead of the default TOTP TFA.